### PR TITLE
Add Azure Cosmos DB MongoDB vCore Module

### DIFF
--- a/cosmosdb-mongo-vcore/credentials.tf
+++ b/cosmosdb-mongo-vcore/credentials.tf
@@ -2,7 +2,5 @@ resource "random_password" "password" {
   length           = 32
   min_lower        = 4
   min_numeric      = 4
-  min_special      = 4
   min_upper        = 4
-  override_special = "!#$%&*-_=+[]{}:?"
 }

--- a/cosmosdb-mongo-vcore/credentials.tf
+++ b/cosmosdb-mongo-vcore/credentials.tf
@@ -1,8 +1,3 @@
-resource "random_pet" "username" {
-  length    = 2   # Number of words in the generated name
-  separator = "-" # Separator between words
-}
-
 resource "random_password" "password" {
   length           = 32
   min_lower        = 4

--- a/cosmosdb-mongo-vcore/credentials.tf
+++ b/cosmosdb-mongo-vcore/credentials.tf
@@ -1,0 +1,13 @@
+resource "random_pet" "username" {
+  length    = 2   # Number of words in the generated name
+  separator = "-" # Separator between words
+}
+
+resource "random_password" "password" {
+  length           = 32
+  min_lower        = 4
+  min_numeric      = 4
+  min_special      = 4
+  min_upper        = 4
+  override_special = "!#$%&*-_=+[]{}:?"
+}

--- a/cosmosdb-mongo-vcore/credentials.tf
+++ b/cosmosdb-mongo-vcore/credentials.tf
@@ -2,5 +2,7 @@ resource "random_password" "password" {
   length           = 32
   min_lower        = 4
   min_numeric      = 4
+  min_special      = 4
   min_upper        = 4
+  override_special = "!#$%&*-_=+[]{}:?"
 }

--- a/cosmosdb-mongo-vcore/mongo.tf
+++ b/cosmosdb-mongo-vcore/mongo.tf
@@ -21,7 +21,7 @@ resource "azurerm_mongo_cluster" "mongo" {
   storage_size_in_gb     = var.storage_size_in_gb
   high_availability_mode = var.high_availability_mode
 
-  administrator_username = random_pet.username.id
+  administrator_username = var.admin_user
   administrator_password = random_password.password.result
 
   tags = {
@@ -32,9 +32,6 @@ resource "azurerm_mongo_cluster" "mongo" {
     Temporary       = upper(var.temporary)
 
   }
-  
-  depends_on = [
-    random_pet.username,
-    random_password.password
-  ]
+
+  depends_on = [random_password.password]
 }

--- a/cosmosdb-mongo-vcore/mongo.tf
+++ b/cosmosdb-mongo-vcore/mongo.tf
@@ -24,6 +24,10 @@ resource "azurerm_mongo_cluster" "mongo" {
   administrator_username = var.admin_user
   administrator_password = random_password.password.result
 
+  create_mode = var.mongo_create_mode
+  version     = var.mongo_version
+
+
   tags = {
     Environment     = upper(var.environment)
     Orchestrator    = "Terraform"

--- a/cosmosdb-mongo-vcore/mongo.tf
+++ b/cosmosdb-mongo-vcore/mongo.tf
@@ -1,0 +1,35 @@
+resource "azurerm_resource_group" "mongo_rg" {
+  name     = var.resource_group_name
+  location = var.location
+  tags = {
+    Environment     = upper(var.environment)
+    Orchestrator    = "Terraform"
+    DisplayName     = upper(var.resource_group_name)
+    ApplicationName = lower(var.application_name)
+    Temporary       = upper(var.temporary)
+  }
+}
+
+resource "azurerm_mongo_cluster" "mongo" {
+  name                  = var.mongodb_cluster_name
+  resource_group_name   = azurerm_resource_group.mongo_rg.name
+  location              = azurerm_resource_group.mongo_rg.location
+  public_network_access = var.public_network_access
+
+  compute_tier           = var.compute_tier
+  shard_count            = var.shard_count
+  storage_size_in_gb     = var.storage_size_in_gb
+  high_availability_mode = var.high_availability_mode
+
+  administrator_username = random_pet.username.id
+  administrator_password = random_password.password.result
+
+  tags = {
+    Environment     = upper(var.environment)
+    Orchestrator    = "Terraform"
+    DisplayName     = upper(var.mongodb_cluster_name)
+    ApplicationName = lower(var.application_name)
+    Temporary       = upper(var.temporary)
+
+  }
+}

--- a/cosmosdb-mongo-vcore/mongo.tf
+++ b/cosmosdb-mongo-vcore/mongo.tf
@@ -32,4 +32,9 @@ resource "azurerm_mongo_cluster" "mongo" {
     Temporary       = upper(var.temporary)
 
   }
+  
+  depends_on = [
+    random_pet.username,
+    random_password.password
+  ]
 }

--- a/cosmosdb-mongo-vcore/output.tf
+++ b/cosmosdb-mongo-vcore/output.tf
@@ -20,7 +20,8 @@ output "public_access_enabled" {
 
 output "mongodb_admin_username" {
   description = "Azure Mongo DB admin username"
-  value       = random_pet.username.id
+  value       = azurerm_mongo_cluster.mongo.administrator_username
+  sensitive   = false
 }
 
 output "mongodb_admin_password" {

--- a/cosmosdb-mongo-vcore/output.tf
+++ b/cosmosdb-mongo-vcore/output.tf
@@ -23,6 +23,12 @@ output "mongodb_admin_username" {
   value       = random_pet.username.id
 }
 
+output "mongodb_admin_password" {
+  description = "Azure Mongo DB admin password"
+  value       = nonsensitive(random_password.password.result)
+  sensitive   = false
+}
+
 output "mongodb_compute_tier" {
   description = "Azure Mongo DB compute tier"
   value       = azurerm_mongo_cluster.mongo.compute_tier

--- a/cosmosdb-mongo-vcore/output.tf
+++ b/cosmosdb-mongo-vcore/output.tf
@@ -1,0 +1,39 @@
+output "resource_group" {
+  description = "Azure mongo DB resource group name"
+  value       = azurerm_resource_group.mongo_rg.name
+}
+
+output "mongodb_cluster_name" {
+  description = "Azure Mongo DB name"
+  value       = azurerm_mongo_cluster.mongo.name
+}
+
+output "mongodb_location" {
+  description = "Azure mongo DB  location"
+  value       = azurerm_mongo_cluster.mongo.location
+}
+
+output "public_access_enabled" {
+  description = "Azure Mongo DB enabled public access or not"
+  value       = azurerm_mongo_cluster.mongo.public_network_access
+}
+
+output "mongodb_admin_username" {
+  description = "Azure Mongo DB admin username"
+  value       = random_pet.username.id
+}
+
+output "mongodb_compute_tier" {
+  description = "Azure Mongo DB compute tier"
+  value       = azurerm_mongo_cluster.mongo.compute_tier
+}
+
+output "mongodb_shard_count" {
+  description = "Azure Mongo DB shard count"
+  value       = azurerm_mongo_cluster.mongo.shard_count
+}
+
+output "mongodb_storage_size" {
+  description = "Azure Mongo DB storage size in GB"
+  value       = azurerm_mongo_cluster.mongo.storage_size_in_gb
+}

--- a/cosmosdb-mongo-vcore/providers.tf
+++ b/cosmosdb-mongo-vcore/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.3"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "<= 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.1"
+    }
+  }
+}
+provider "azurerm" {
+  features {}
+}

--- a/cosmosdb-mongo-vcore/providers.tf
+++ b/cosmosdb-mongo-vcore/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "<= 4.0"
+      version = ">= 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/cosmosdb-mongo-vcore/variables.tf
+++ b/cosmosdb-mongo-vcore/variables.tf
@@ -14,7 +14,16 @@ variable "mongodb_cluster_name" {
   description = "Azure Mongo DB name"
   type        = string
   default     = ""
+}
 
+variable "admin_user" {
+  description = "Azure Mongo DB admin username"
+  type        = string
+  default     = ""
+  validation {
+    condition     = length(var.admin_user) > 0
+    error_message = "The admin_user variable must be set to a non-empty string."
+  }
 }
 
 variable "environment" {

--- a/cosmosdb-mongo-vcore/variables.tf
+++ b/cosmosdb-mongo-vcore/variables.tf
@@ -94,3 +94,25 @@ variable "high_availability_mode" {
     error_message = "The high_availability_mode value must be either 'Disabled', 'ZoneRedundantPreferred'."
   }
 }
+
+variable "mongo_create_mode" {
+  description = "The create mode for the MongoDB Cluster"
+  default     = "Default"
+  type        = string
+  validation {
+    condition     = contains(["Default", "GeoReplica"], var.mongo_create_mode)
+    error_message = "The mongo_create_mode value must be either 'Default' or 'GeoReplica'."
+  }
+
+}
+
+variable "mongo_version" {
+  description = "The version of the MongoDB Cluster"
+  default     = "7.0"
+  type        = string
+  validation {
+    condition     = contains(["5.0", "6.0", "7.0"], var.mongo_version)
+    error_message = "The mongo_version value must be either '5.0', '6.0', or '7.0'."
+  }
+
+}

--- a/cosmosdb-mongo-vcore/variables.tf
+++ b/cosmosdb-mongo-vcore/variables.tf
@@ -1,0 +1,87 @@
+variable "resource_group_name" {
+  type        = string
+  description = "Azure Mongo DB Rg"
+  default     = ""
+}
+
+variable "location" {
+  type        = string
+  description = "Azure Mongo DB location"
+  default     = ""
+}
+
+variable "mongodb_cluster_name" {
+  description = "Azure Mongo DB name"
+  type        = string
+  default     = ""
+
+}
+
+variable "environment" {
+  default     = "DEV"
+  description = "Environment tag value in Azure"
+  type        = string
+  validation {
+    condition     = contains(["DEV", "QA", "UAT", "PROD"], var.environment)
+    error_message = "Environment value should be one among DEV or QA or UAT or PROD."
+  }
+}
+
+variable "application_name" {
+  default     = "devwithkrishna"
+  description = "Azure application name tag"
+}
+
+
+variable "temporary" {
+  default     = "TRUE"
+  description = "Temporary tag value in Azure"
+  type        = string
+  validation {
+    condition     = contains(["TRUE", "FALSE"], upper(var.temporary))
+    error_message = "The temporary tag value must be either 'TRUE' or 'FALSE'."
+  }
+
+}
+
+variable "compute_tier" {
+  description = "The compute tier to assign to the MongoDB Cluster"
+  default     = "Free"
+  type        = string
+  validation {
+    condition     = contains(["Free", "M10", "M20", "M25", "M30", "M40", "M50", "M60", "M80", "M200"], var.compute_tier)
+    error_message = "The compute_tier value must be one of the following: 'Free', 'M10', 'M20', 'M25', 'M30', 'M40', 'M50', 'M60', 'M80', or 'M200'."
+  }
+}
+
+variable "shard_count" {
+  description = "The Number of shards to provision on the MongoDB Cluster"
+  type        = number
+  default     = 1
+}
+
+variable "public_network_access" {
+  default     = "Enabled"
+  description = "Public Network Access setting for the MongoDB Cluster"
+  type        = string
+  validation {
+    condition     = contains(["Enabled", "Disabled"], var.public_network_access)
+    error_message = "The public_network_access value must be either 'Enabled' or 'Disabled'."
+  }
+}
+
+variable "storage_size_in_gb" {
+  default     = 32
+  description = "The storage size in GB for the MongoDB Cluster"
+  type        = number
+}
+
+variable "high_availability_mode" {
+  description = "The high availability mode for the MongoDB Cluster"
+  default     = "Disabled"
+  type        = string
+  validation {
+    condition     = contains(["ZoneRedundantPreferred", "Disabled"], var.high_availability_mode)
+    error_message = "The high_availability_mode value must be either 'Disabled', 'ZoneRedundantPreferred'."
+  }
+}


### PR DESCRIPTION
This pull request introduces a Terraform module to deploy an Azure Cosmos DB MongoDB vCore Cluster. The module supports flexible configurations for compute, storage, and high availability, making it suitable for various environments such as development, QA, UAT, and production.

### Pull Request Title:
**Add Azure Cosmos DB MongoDB vCore Module**

### Pull Request Description:

#### 🔍 Overview:
This pull request introduces a Terraform module to deploy an **Azure Cosmos DB MongoDB vCore Cluster**. The module supports flexible configurations for compute, storage, and high availability, making it suitable for various environments such as development, QA, UAT, and production.

---

#### 📝 Changes Made:
1. **Resource Group Creation**:
   - Creates a resource group for the MongoDB cluster with environment-specific tags.

2. **MongoDB Cluster Deployment**:
   - Deploys an Azure Cosmos DB MongoDB vCore cluster with the following configurable features:
     - **Compute Tier**: Supports tiers like `Free`, `M10`, `M20`, etc.
     - **Shard Count**: Configurable number of shards for horizontal scaling.
     - **Storage Size**: Adjustable storage size in GB.
     - **High Availability Mode**: Options for `Disabled` or `ZoneRedundantPreferred`.
     - **Public Network Access**: Configurable to `Enabled` or `Disabled`.

3. **Randomized Credentials**:
   - Generates a secure administrator username using the `random_pet` resource.
   - Generates a strong administrator password using the `random_password` resource.

4. **Tagging**:
   - Adds tags for better resource organization:
     - `Environment`, `Orchestrator`, `DisplayName`, `ApplicationName`, and `Temporary`.

5. **Outputs**:
   - Provides outputs for key resources and configurations:
     - Resource group name, MongoDB cluster name, location, compute tier, shard count, storage size, and public access status.
     - Administrator username for the MongoDB cluster.

6. **Validation**:
   - Includes validation for variables to ensure proper values are provided:
     - `compute_tier`: Must be one of `Free`, `M10`, `M20`, etc.
     - `public_network_access`: Must be `Enabled` or `Disabled`.
     - `high_availability_mode`: Must be `Disabled` or `ZoneRedundantPreferred`.
     - `environment`: Must be one of `DEV`, `QA`, `UAT`, or `PROD`.


DEVOPS-314 mongo Db cosmos cluster Azure