### PR TITLE
Add Terraform module for Azure DNS Zone creation

### DIFF
--- a/dns-zone/dnszone.tf
+++ b/dns-zone/dnszone.tf
@@ -1,0 +1,27 @@
+resource "azurerm_resource_group" "dns_rg" {
+  name     = var.resource_group_name
+  location = var.location
+  tags = {
+    Environment     = upper(var.environment)
+    Orchestrator    = "Terraform"
+    DisplayName     = upper(var.resource_group_name)
+    ApplicationName = lower(var.application_name)
+    Temporary       = upper(var.temporary)
+  }
+}
+
+resource "azurerm_dns_zone" "dns" {
+  name                = var.dns_zone_name
+  resource_group_name = azurerm_resource_group.mongo_rg.name
+
+  tags = {
+    Environment     = upper(var.environment)
+    Orchestrator    = "Terraform"
+    DisplayName     = upper(var.dns_zone_name)
+    ApplicationName = lower(var.application_name)
+    Temporary       = upper(var.temporary)
+
+  }
+
+  depends_on = [azurerm_resource_group.dns_rg]
+}

--- a/dns-zone/dnszone.tf
+++ b/dns-zone/dnszone.tf
@@ -12,7 +12,7 @@ resource "azurerm_resource_group" "dns_rg" {
 
 resource "azurerm_dns_zone" "dns" {
   name                = var.dns_zone_name
-  resource_group_name = azurerm_resource_group.mongo_rg.name
+  resource_group_name = azurerm_resource_group.dns_rg.name
 
   tags = {
     Environment     = upper(var.environment)

--- a/dns-zone/output.tf
+++ b/dns-zone/output.tf
@@ -13,7 +13,7 @@ output "resource_group_location" {
   value       = azurerm_resource_group.dns_rg.location
 }
 
-output "dns_id" {
+output "dns_zone_id" {
   description = "DNS zone ID"
   value       = azurerm_dns_zone.dns.i
 

--- a/dns-zone/output.tf
+++ b/dns-zone/output.tf
@@ -15,7 +15,7 @@ output "resource_group_location" {
 
 output "dns_zone_id" {
   description = "DNS zone ID"
-  value       = azurerm_dns_zone.dns.i
+  value       = azurerm_dns_zone.dns.id
 
 }
 

--- a/dns-zone/output.tf
+++ b/dns-zone/output.tf
@@ -1,0 +1,26 @@
+output "resource_group" {
+  description = "Azure DNS Zone resource group name"
+  value       = azurerm_resource_group.dns_rg.name
+}
+
+output "dns_zone_name" {
+  description = "Azure DNS zone name"
+  value       = azurerm_dns_zone.dns.name
+}
+
+output "resource_group_location" {
+  description = "Azure resource group location"
+  value       = azurerm_resource_group.dns_rg.location
+}
+
+output "dns_id" {
+  description = "DNS zone ID"
+  value       = azurerm_dns_zone.dns.i
+
+}
+
+output "name_servers" {
+  description = "Name servers for the DNS zone"
+  value       = azurerm_dns_zone.dns.name_servers
+
+}

--- a/dns-zone/providers.tf
+++ b/dns-zone/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.3"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.1"
+    }
+  }
+}
+provider "azurerm" {
+  features {}
+}

--- a/dns-zone/variables.tf
+++ b/dns-zone/variables.tf
@@ -1,0 +1,118 @@
+variable "resource_group_name" {
+  type        = string
+  description = "Azure Mongo DB Rg"
+  default     = ""
+}
+
+variable "location" {
+  type        = string
+  description = "Azure Mongo DB location"
+  default     = ""
+}
+
+variable "mongodb_cluster_name" {
+  description = "Azure Mongo DB name"
+  type        = string
+  default     = ""
+}
+
+variable "admin_user" {
+  description = "Azure Mongo DB admin username"
+  type        = string
+  default     = ""
+  validation {
+    condition     = length(var.admin_user) > 0
+    error_message = "The admin_user variable must be set to a non-empty string."
+  }
+}
+
+variable "environment" {
+  default     = "DEV"
+  description = "Environment tag value in Azure"
+  type        = string
+  validation {
+    condition     = contains(["DEV", "QA", "UAT", "PROD"], var.environment)
+    error_message = "Environment value should be one among DEV or QA or UAT or PROD."
+  }
+}
+
+variable "application_name" {
+  default     = "devwithkrishna"
+  description = "Azure application name tag"
+}
+
+
+variable "temporary" {
+  default     = "TRUE"
+  description = "Temporary tag value in Azure"
+  type        = string
+  validation {
+    condition     = contains(["TRUE", "FALSE"], upper(var.temporary))
+    error_message = "The temporary tag value must be either 'TRUE' or 'FALSE'."
+  }
+
+}
+
+variable "compute_tier" {
+  description = "The compute tier to assign to the MongoDB Cluster"
+  default     = "Free"
+  type        = string
+  validation {
+    condition     = contains(["Free", "M10", "M20", "M25", "M30", "M40", "M50", "M60", "M80", "M200"], var.compute_tier)
+    error_message = "The compute_tier value must be one of the following: 'Free', 'M10', 'M20', 'M25', 'M30', 'M40', 'M50', 'M60', 'M80', or 'M200'."
+  }
+}
+
+variable "shard_count" {
+  description = "The Number of shards to provision on the MongoDB Cluster"
+  type        = number
+  default     = 1
+}
+
+variable "public_network_access" {
+  default     = "Enabled"
+  description = "Public Network Access setting for the MongoDB Cluster"
+  type        = string
+  validation {
+    condition     = contains(["Enabled", "Disabled"], var.public_network_access)
+    error_message = "The public_network_access value must be either 'Enabled' or 'Disabled'."
+  }
+}
+
+variable "storage_size_in_gb" {
+  default     = 32
+  description = "The storage size in GB for the MongoDB Cluster"
+  type        = number
+}
+
+variable "high_availability_mode" {
+  description = "The high availability mode for the MongoDB Cluster"
+  default     = "Disabled"
+  type        = string
+  validation {
+    condition     = contains(["ZoneRedundantPreferred", "Disabled"], var.high_availability_mode)
+    error_message = "The high_availability_mode value must be either 'Disabled', 'ZoneRedundantPreferred'."
+  }
+}
+
+variable "mongo_create_mode" {
+  description = "The create mode for the MongoDB Cluster"
+  default     = "Default"
+  type        = string
+  validation {
+    condition     = contains(["Default", "GeoReplica"], var.mongo_create_mode)
+    error_message = "The mongo_create_mode value must be either 'Default' or 'GeoReplica'."
+  }
+
+}
+
+variable "mongo_version" {
+  description = "The version of the MongoDB Cluster"
+  default     = "7.0"
+  type        = string
+  validation {
+    condition     = contains(["5.0", "6.0", "7.0"], var.mongo_version)
+    error_message = "The mongo_version value must be either '5.0', '6.0', or '7.0'."
+  }
+
+}

--- a/dns-zone/variables.tf
+++ b/dns-zone/variables.tf
@@ -1,30 +1,21 @@
 variable "resource_group_name" {
   type        = string
-  description = "Azure Mongo DB Rg"
+  description = "Azure DNS Zone Rg"
   default     = ""
 }
 
 variable "location" {
   type        = string
-  description = "Azure Mongo DB location"
+  description = "Azure DNS RG location"
   default     = ""
 }
 
-variable "mongodb_cluster_name" {
-  description = "Azure Mongo DB name"
+variable "dns_zone_name" {
+  description = "Azure DNS Zone name"
   type        = string
   default     = ""
 }
 
-variable "admin_user" {
-  description = "Azure Mongo DB admin username"
-  type        = string
-  default     = ""
-  validation {
-    condition     = length(var.admin_user) > 0
-    error_message = "The admin_user variable must be set to a non-empty string."
-  }
-}
 
 variable "environment" {
   default     = "DEV"
@@ -53,66 +44,3 @@ variable "temporary" {
 
 }
 
-variable "compute_tier" {
-  description = "The compute tier to assign to the MongoDB Cluster"
-  default     = "Free"
-  type        = string
-  validation {
-    condition     = contains(["Free", "M10", "M20", "M25", "M30", "M40", "M50", "M60", "M80", "M200"], var.compute_tier)
-    error_message = "The compute_tier value must be one of the following: 'Free', 'M10', 'M20', 'M25', 'M30', 'M40', 'M50', 'M60', 'M80', or 'M200'."
-  }
-}
-
-variable "shard_count" {
-  description = "The Number of shards to provision on the MongoDB Cluster"
-  type        = number
-  default     = 1
-}
-
-variable "public_network_access" {
-  default     = "Enabled"
-  description = "Public Network Access setting for the MongoDB Cluster"
-  type        = string
-  validation {
-    condition     = contains(["Enabled", "Disabled"], var.public_network_access)
-    error_message = "The public_network_access value must be either 'Enabled' or 'Disabled'."
-  }
-}
-
-variable "storage_size_in_gb" {
-  default     = 32
-  description = "The storage size in GB for the MongoDB Cluster"
-  type        = number
-}
-
-variable "high_availability_mode" {
-  description = "The high availability mode for the MongoDB Cluster"
-  default     = "Disabled"
-  type        = string
-  validation {
-    condition     = contains(["ZoneRedundantPreferred", "Disabled"], var.high_availability_mode)
-    error_message = "The high_availability_mode value must be either 'Disabled', 'ZoneRedundantPreferred'."
-  }
-}
-
-variable "mongo_create_mode" {
-  description = "The create mode for the MongoDB Cluster"
-  default     = "Default"
-  type        = string
-  validation {
-    condition     = contains(["Default", "GeoReplica"], var.mongo_create_mode)
-    error_message = "The mongo_create_mode value must be either 'Default' or 'GeoReplica'."
-  }
-
-}
-
-variable "mongo_version" {
-  description = "The version of the MongoDB Cluster"
-  default     = "7.0"
-  type        = string
-  validation {
-    condition     = contains(["5.0", "6.0", "7.0"], var.mongo_version)
-    error_message = "The mongo_version value must be either '5.0', '6.0', or '7.0'."
-  }
-
-}


### PR DESCRIPTION

This PR introduces a new Terraform module to manage Azure DNS Zones. The module allows for the creation and configuration of DNS zones within a specified resource group, supporting customization of:

* DNS zone name

* Resource group and location

* Tags for resource management


**Features**:

* Creates a azurerm_dns_zone resource.

* Outputs zone name, name servers, and resource ID.

* Supports tagging and reusability through input variables.

* Modular design 


DEVOPS-332 terraform module for DNs zone